### PR TITLE
Correct XML namespace in PHPDOX configuration - resolves #118

### DIFF
--- a/configuration.html
+++ b/configuration.html
@@ -58,7 +58,7 @@
     <p>More information can be found in the <a href="https://phpunit.de/manual/current/en/appendixes.configuration.html">documentation</a> for PHPUnit.</p>
     <h2>phpDox</h2>
     <p>The <code>phpdox</code> task in the <code>build.xml</code> (see "<a href="automation.html">Automation</a>") assumes that an XML configuration file for phpDox is used to configure the API documentation generation:</p>
-    <pre><code>&lt;phpdox xmlns="http://phpdox.net/config"&gt;
+    <pre><code>&lt;phpdox xmlns="http://xml.phpdox.net/config"&gt;
  &lt;project name="name-of-project" source="src" workdir="build/phpdox"&gt;
   &lt;collector publiconly="false"&gt;
    &lt;include mask="*.php" /&gt;


### PR DESCRIPTION
PHPDOX have changed their XML namespace. Resolves #118
